### PR TITLE
Use `gpio_read` to toggle led state, saves 24 bytes of flash.

### DIFF
--- a/src/BlueSCSI.cpp
+++ b/src/BlueSCSI.cpp
@@ -535,9 +535,7 @@ void onFalseInit(void)
   LOG_FILE.sync();
   while(true) {
     for(int i = 0; i < 3; i++) {
-      gpio_write(LED, high);
-      delay(250);
-      gpio_write(LED, low);
+      gpio_write(LED, !gpio_read(LED));
       delay(250);
     }
     delay(3000);
@@ -551,9 +549,7 @@ void noSDCardFound(void)
 {
   while(true) {
     for(int i = 0; i < 5; i++) {
-      gpio_write(LED, high);
-      delay(250);
-      gpio_write(LED, low);
+      gpio_write(LED, !gpio_read(LED));
       delay(250);
     }
     delay(3000);


### PR DESCRIPTION
Uses a teensy bit less flash, same memory footprint:

```
RAM:   [====      ]  42.9% (used 8784 bytes from 20480 bytes)
Flash: [========  ]  81.0% (used 53076 bytes from 65536 bytes)

RAM:   [====      ]  42.9% (used 8784 bytes from 20480 bytes)
Flash: [========  ]  81.0% (used 53052 bytes from 65536 bytes)
```