### PR TITLE
Add Github Action workflow that ensures the project compiles

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,34 @@
+# Based on https://docs.platformio.org/en/latest/integration/ci/github-actions.html
+name: PlatformIO CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Cache pip
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+    - name: Cache PlatformIO
+      uses: actions/cache@v2
+      with:
+        path: ~/.platformio
+        key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
+    - name: Set up Python
+      uses: actions/setup-python@v2
+    - name: Install PlatformIO
+      run: |
+        python -m pip install --upgrade pip
+        pip install --upgrade platformio
+
+    - name: Install library dependencies
+      run: pio lib -g install 1
+
+    - name: Run PlatformIO
+      run: pio ci --project-conf platformio.ini .


### PR DESCRIPTION
A Github Action workflow (based on https://docs.platformio.org/en/latest/integration/ci/github-actions.html) that automatically builds the project for all devices listed in platformio.ini.

Not a big deal right now, but will be helpful in the future when we have more than one target device or arch.