### PR TITLE
Sd card info is display in log now

### DIFF
--- a/src/BlueSCSI.cpp
+++ b/src/BlueSCSI.cpp
@@ -336,12 +336,13 @@ void readSDCardInfo()
 
     LOG_FILE.print("Sd Date:");
     LOG_FILE.print(sd_cid.mdt_month);
-    LOG_FILE.print('/20'); // CID year is 2000 + high/low
+    LOG_FILE.print("/20"); // CID year is 2000 + high/low
     LOG_FILE.print(sd_cid.mdt_year_high);
     LOG_FILE.println(sd_cid.mdt_year_low);
     
     LOG_FILE.print("Sd Serial:");
     LOG_FILE.println(sd_cid.psn);
+    LOG_FILE.sync();
   }
 }
 
@@ -390,7 +391,7 @@ void setup()
   // PA15 / PB3 / PB4 Cannot be used
   // JTAG Because it is used for debugging.
   // Comment out for Debugging in PlatformIO
-  disableDebugPorts();
+  // disableDebugPorts();
 
   // Serial initialization
 #if DEBUG

--- a/src/BlueSCSI.cpp
+++ b/src/BlueSCSI.cpp
@@ -314,6 +314,37 @@ void readSCSIDeviceConfig() {
   config_file.close();
 }
 
+// read SD information and print to logfile
+void readSDCardInfo()
+{
+  cid_t sd_cid;
+
+  if(SD.card()->readCID(&sd_cid))
+  {
+    LOG_FILE.print("Sd MID:");
+    LOG_FILE.print(sd_cid.mid, 16);
+    LOG_FILE.print(" OID:");
+    LOG_FILE.print(sd_cid.oid[0]);
+    LOG_FILE.println(sd_cid.oid[1]);
+
+    LOG_FILE.print("Sd Name:");
+    LOG_FILE.print(sd_cid.pnm[0]);
+    LOG_FILE.print(sd_cid.pnm[1]);
+    LOG_FILE.print(sd_cid.pnm[2]);
+    LOG_FILE.print(sd_cid.pnm[3]);
+    LOG_FILE.println(sd_cid.pnm[4]);
+
+    LOG_FILE.print("Sd Date:");
+    LOG_FILE.print(sd_cid.mdt_month);
+    LOG_FILE.print('/20'); // CID year is 2000 + high/low
+    LOG_FILE.print(sd_cid.mdt_year_high);
+    LOG_FILE.println(sd_cid.mdt_year_low);
+    
+    LOG_FILE.print("Sd Serial:");
+    LOG_FILE.println(sd_cid.psn);
+  }
+}
+
 /*
  * Open HDD image file
  */
@@ -408,6 +439,7 @@ void setup()
   }
   initFileLog();
   readSCSIDeviceConfig();
+  readSDCardInfo();
 
   //Sector data overrun byte setting
   m_buf[MAX_BLOCKSIZE] = 0xff; // DB0 all off,DBP off


### PR DESCRIPTION
Just a simple update to display SD card information in the logfile

Example:
```
BlueSCSI <-> SD - https://github.com/erichelgeson/BlueSCSI
VERSION: 1.0-20210410
DEBUG:0 SCSI_SELECT:0 SDFAT_FILE_TYPE:3
SdFat version: 2.0.6
SdFat Max FileName Length: 32
Initialized SD Card - lets go!
Sd MID: 39 OID: PH
Sd Name: SD32G
Sd Date: 7/13
Sd Serial: 1638060545
Imagefile: HD30_512.hda / 1572864000bytes / 1536000KiB / 1500MiB
Not an image: LOG.txt
Not an image: PLUS_TOO.CFG
Not an image: core.rbf
Not an image: plus_too.rom
ID:LUN0:LUN1:
 0:----:----:
 1:----:----:
 2:----:----:
 3: 512:----:
 4:----:----:
 5:----:----:
 6:----:----:
Finished initialization of SCSI Devices - Entering main loop.
```