### PR TITLE
Optimize handling of reset interrupt.

### DIFF
--- a/src/BlueSCSI.cpp
+++ b/src/BlueSCSI.cpp
@@ -640,7 +640,8 @@ void longjmpFromInterrupt(jmp_buf jmpb, int retval) {
       str %2, [sp, #20];\
       str %3, [sp, #24];\
       str %4, [sp, #28];\
-      ldr lr, =0xfffffff9"
+      ldr lr, =0xfffffff9;\
+      bx lr"
        :: "r"(jmpb),"r"(retval),"r"(zero), "r"(longjmpaddr), "r"(PSR)
   );
 }

--- a/src/BlueSCSI.cpp
+++ b/src/BlueSCSI.cpp
@@ -217,14 +217,9 @@ byte          m_msb[256];             // Command storage bytes
 // Set DBP, set REQ = inactive
 #define DBP(D)    ((((((uint32_t)(D)<<8)|PTY(D))*0x00010001)^0x0000ff01)|BITMASK(vREQ))
 
-#define DBP8(D)   DBP(D),DBP(D+1),DBP(D+2),DBP(D+3),DBP(D+4),DBP(D+5),DBP(D+6),DBP(D+7)
-#define DBP32(D)  DBP8(D),DBP8(D+8),DBP8(D+16),DBP8(D+24)
-
 // BSRR register control value that simultaneously performs DB set, DP set, and REQ = H (inactrive)
-static const uint32_t db_bsrr[256]={
-  DBP32(0x00),DBP32(0x20),DBP32(0x40),DBP32(0x60),
-  DBP32(0x80),DBP32(0xA0),DBP32(0xC0),DBP32(0xE0)
-};
+uint32_t db_bsrr[256];
+
 // Parity bit acquisition
 #define PARITY(DB) (db_bsrr[DB]&1)
 
@@ -382,6 +377,11 @@ void setup()
   // PA15 / PB3 / PB4 Cannot be used
   // JTAG Because it is used for debugging.
   disableDebugPorts();
+
+  // Setup BSRR table
+  for (unsigned i = 0; i <= 255; i++) {
+    db_bsrr[i] = DBP(i);
+  }
 
   // Serial initialization
 #if DEBUG > 0

--- a/src/BlueSCSI.cpp
+++ b/src/BlueSCSI.cpp
@@ -153,22 +153,22 @@ SdFs SD;
 // IN , FLOAT      : 4
 // IN , PU/PD      : 8
 // OUT, PUSH/PULL  : 3
-// OUT, OD         : 1
-//#define DB_MODE_OUT 3
-#define DB_MODE_OUT 1
+// OUT, OD         : 7
+#define DB_MODE_OUT 3
+//#define DB_MODE_OUT 7
 #define DB_MODE_IN  8
 
 // Put DB and DP in output mode
 #define SCSI_DB_OUTPUT() { PBREG->CRL=(PBREG->CRL &0xfffffff0)|DB_MODE_OUT; PBREG->CRH = 0x11111111*DB_MODE_OUT; }
 // Put DB and DP in input mode
-#define SCSI_DB_INPUT()  { PBREG->CRL=(PBREG->CRL &0xfffffff0)|DB_MODE_IN ; PBREG->CRH = 0x11111111*DB_MODE_IN;  }
+#define SCSI_DB_INPUT()  { PBREG->CRL=(PBREG->CRL &0xfffffff0)|DB_MODE_IN ; PBREG->CRH = 0x11111111*DB_MODE_IN; if (DB_MODE_IN == 8) PBREG->BSRR = 0xFF01;}
 
 // Turn on the output only for BSY
 #define SCSI_BSY_ACTIVE()      { gpio_mode(BSY, GPIO_OUTPUT_OD); SCSI_OUT(vBSY,  active) }
 // BSY,REQ,MSG,CD,IO Turn on the output (no change required for OD)
-#define SCSI_TARGET_ACTIVE()   { }
+#define SCSI_TARGET_ACTIVE()   { if (DB_MODE_OUT != 7) gpio_mode(REQ, GPIO_OUTPUT_PP);}
 // BSY,REQ,MSG,CD,IO Turn off output, BSY is the last input
-#define SCSI_TARGET_INACTIVE() { SCSI_OUT(vREQ,inactive); SCSI_OUT(vMSG,inactive); SCSI_OUT(vCD,inactive);SCSI_OUT(vIO,inactive); SCSI_OUT(vBSY,inactive); gpio_mode(BSY, GPIO_INPUT_PU); }
+#define SCSI_TARGET_INACTIVE() { if (DB_MODE_OUT == 7) SCSI_OUT(vREQ,inactive) else { if (DB_MODE_IN == 8) gpio_mode(REQ, GPIO_INPUT_PU) else gpio_mode(REQ, GPIO_INPUT_FLOATING)} SCSI_OUT(vMSG,inactive); SCSI_OUT(vCD,inactive);SCSI_OUT(vIO,inactive); SCSI_OUT(vBSY,inactive); gpio_mode(BSY, GPIO_INPUT_PU); }
 
 // HDDiamge file
 #define HDIMG_ID_POS  2                 // Position to embed ID number

--- a/src/BlueSCSI.cpp
+++ b/src/BlueSCSI.cpp
@@ -168,7 +168,7 @@ SdFs SD;
 // BSY,REQ,MSG,CD,IO Turn on the output (no change required for OD)
 #define SCSI_TARGET_ACTIVE()   { if (DB_MODE_OUT != 7) gpio_mode(REQ, GPIO_OUTPUT_PP);}
 // BSY,REQ,MSG,CD,IO Turn off output, BSY is the last input
-#define SCSI_TARGET_INACTIVE() { if (DB_MODE_OUT == 7) SCSI_OUT(vREQ,inactive) else { if (DB_MODE_IN == 8) gpio_mode(REQ, GPIO_INPUT_PU) else gpio_mode(REQ, GPIO_INPUT_FLOATING)} SCSI_OUT(vMSG,inactive); SCSI_OUT(vCD,inactive);SCSI_OUT(vIO,inactive); SCSI_OUT(vBSY,inactive); gpio_mode(BSY, GPIO_INPUT_PU); }
+#define SCSI_TARGET_INACTIVE() { if (DB_MODE_OUT == 7) SCSI_OUT(vREQ,inactive) else { if (DB_MODE_IN == 8) gpio_mode(REQ, GPIO_INPUT_PU) else gpio_mode(REQ, GPIO_INPUT_FLOATING)} SCSI_OUT(vMSG,inactive); SCSI_OUT(vCD,inactive);SCSI_OUT(vIO,inactive); gpio_mode(BSY, GPIO_INPUT_PU); }
 
 // HDDiamge file
 #define HDIMG_ID_POS  2                 // Position to embed ID number


### PR DESCRIPTION
For your consideration, here is an optimization of reset handling.

Rather than polling m_isBusReset all over the place, I've changed the code to set up longjmp that can be used for a bus reset, then added the necessary code to call that from the interrupt handler. That does require a little bit of assembly.

I've gated the reset handling so it doesn't fire in the middle of a read, write, or flush of the image file. Flush will also be called now if there is a reset while a write was in progress.

I'm seeing about a 5% increase in read speed, and 10% increase in write speed on the computer I'm testing this on (Quadra 650, Apple drivers, Hyundai SD card, SCSI Director).

BTW, removed the PIN_MAP from attachInterrupt(). It was working OK because the value returned from PIN_MAP was the same, but if you look at the attachInterrupt function it is doing it's own PIN_MAP.