### PR TITLE
Switch to latest toolchain

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -17,7 +17,7 @@ upload_protocol = stlink
 ; 1.80201.181220 ; 921kb/sec
 ; 1.90201.191206 ; 912kb/sec
 ; 1.90301.200702 ; default - 955kb/sec
-platform_packages = toolchain-gccarmnoneeabi@1.60301.0
+platform_packages = toolchain-gccarmnoneeabi
 
 build_unflags = 
     -Os

--- a/src/BlueSCSI.cpp
+++ b/src/BlueSCSI.cpp
@@ -857,7 +857,7 @@ void readDataPhase(int len, byte* p)
 /*
  * See writeDataLoop for optimization info.
  */
-void readDataLoop(uint32_t blockSize) __attribute__ ((aligned(8)));
+void readDataLoop(uint32_t blockSize) __attribute__ ((aligned(16)));
 void readDataLoop(uint32_t blockSize)
 {
   register byte *dstptr= m_buf;

--- a/src/BlueSCSI.cpp
+++ b/src/BlueSCSI.cpp
@@ -878,7 +878,7 @@ void readDataLoop(uint32_t blockSize)
     REQ_OFF();
     *dstptr++ = ~(ret >> 8);
     // Move wait loop in to a single 8 byte prefetch buffer
-    asm("nop.w");
+    asm("nop.w;nop");
     WAIT_ACK_INACTIVE();
     REQ_ON();
     // Extra 1 cycle delay


### PR DESCRIPTION
I've switched to the latest toolchain. It works great, the read speed was unchanged. The newer compiler is producing slightly better code for writing (readDataLoop function), and with a slight adjustment to the timing, that is benchmarking a fraction faster.

I got these benchmark results:
LC III+: Read 1234 KB/sec, write 861 KB/sec (was 848 KB/sec with old toolchain)
Quadra 650: Read 1143 KB/sec, write 1162 KB/sec (was 950 KB/sec)
PowerMac 7100/80: Read 1266 KB/sec, write 1273 KB/sec (was 1253 KB/sec)
PowerMac G3/266: Read 1273 KB/sec, write 1307 KB/sec (was 1286 KB/sec)