### PR TITLE
Explicitly pinning toolchain to 1.9031.200702 and updating to latest coordinates.

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -10,14 +10,7 @@ lib_deps =
     greiman/SdFat @ ^2.0.6
 upload_protocol = stlink
 ; Different gcc versions produce much different binaries in terms of speed.
-; 1.40804.0 ; 985kb/sec
-; 1.60301.0 ; 1012kb/sec ***
-; 1.70201.0 ; 926kb/sec
-; 1.80301.0 ; 935kb/sec
-; 1.80201.181220 ; 921kb/sec
-; 1.90201.191206 ; 912kb/sec
-; 1.90301.200702 ; default - 955kb/sec
-platform_packages = toolchain-gccarmnoneeabi
+platform_packages = platformio/toolchain-gccarmnoneeabi@1.90301.200702
 
 build_unflags = 
     -Os


### PR DESCRIPTION
Unpinned seemed to just grab the latest cached version.