### PR TITLE
Image set selection

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,5 +3,8 @@
     // for the documentation about the extensions.json format
     "recommendations": [
         "platformio.platformio-ide"
+    ],
+    "unwantedRecommendations": [
+        "ms-vscode.cpptools-extension-pack"
     ]
 }


### PR DESCRIPTION
Allow for BlueSCSI to load image sets without having to move files around on the SD card. As an example this will allow users to use the same BlueSCSI and switch between their Mac Plus, PowerMac, PowerBook, etc without having to remove the SD card and change/move files.

Using Pins A1/B1 and the internal pullup, check at startup and load the appropriate `ImageSetN` folder. Default is to load the root of the SD card so there is no breaking behavior. 

If the optional `/ImageSetAll` directory exists - it will always load images in there. This way you can have a shared drive between all sets.

If an ID conflicts, the last one wins. Order is `ImageSetN`, then `ImageSetAll`.

| A1 | B1 | # |
|-|-|-|
| H  | H  | default `/` or `/ImageSet0` if exists |
| L  | H  | `/ImageSet1`|
| H  | L  | `/ImageSet2` |
| L  | L  | `/ImageSet3` |

Questions: 

* Does `ImageSet` make wording make sense for users?
* We're low on Pins - I chose two - any better choices?

Hardware:

You can add this to any BlueSCSI 1.0-a -> 1.1-a with by PA1, BA1, and Ground to an 3x2 block headers. (photo coming shortly). Future versions of BlueSCSI will have header or jumpers (or both) on the board.