### PR TITLE
Write speed tuning

### DIFF
--- a/src/BlueSCSI.cpp
+++ b/src/BlueSCSI.cpp
@@ -935,14 +935,16 @@ void readDataLoop(uint32_t blockSize, byte* dstptr)
   register gpio_reg_map *port_b = PBREG;
   register volatile uint32_t *port_a_idr = &(GPIOA->regs->IDR);
   REQ_ON();
-  // Start of the do/while and WAIT are already aligned to 8 bytes.
+  // Fastest alignment obtained by trial and error.
+  // Wait loop is within an 8 byte prefetch buffer.
+  asm("nop");
   do {
     WAIT_ACK_ACTIVE();
     uint32_t ret = port_b->IDR;
     REQ_OFF();
     *dstptr++ = ~(ret >> 8);
     // Move wait loop in to a single 8 byte prefetch buffer
-    asm("nop.w;nop");
+    asm("nop;nop;nop");
     WAIT_ACK_INACTIVE();
     REQ_ON();
     // Extra 1 cycle delay


### PR DESCRIPTION
Instruction alignment and pipelining is complicated, I still don't fully understand why the first nop this adds makes things faster.

The second nop change is to add an extra cycle, as the 2 prior instructions (mvn and strb) seem to be pipelining together so the code only had 4 cycles between setting REQ and waiting for ACK.

I'm seeing about a 5% to 7% increase in write speed measured with SCSI Director:
Mac LC III+: Was 865 now 926
Quadra 650: Was 1175 now 1234
PowerMac 7100/80: Was 1280 now 1350
