### PR TITLE
Support for image files larger than 4GB

### DIFF
--- a/src/BlueSCSI.cpp
+++ b/src/BlueSCSI.cpp
@@ -966,8 +966,8 @@ void writeDataPhaseSD(uint32_t adds, uint32_t len)
   SCSI_PHASE_CHANGE(SCSI_PHASE_DATAIN);
   //Bus settle delay 400ns, file.seek() measured at over 1000ns.
 
-  uint32_t pos = adds * m_img->m_blocksize;
-  m_img->m_file.seek(pos);
+  uint64_t pos = (uint64_t)adds * m_img->m_blocksize;
+  m_img->m_file.seekSet(pos);
 
   SCSI_DB_OUTPUT()
   for(uint32_t i = 0; i < len; i++) {
@@ -1061,8 +1061,8 @@ void readDataPhaseSD(uint32_t adds, uint32_t len)
   SCSI_PHASE_CHANGE(SCSI_PHASE_DATAOUT);
   //Bus settle delay 400ns, file.seek() measured at over 1000ns.
 
-  uint32_t pos = adds * m_img->m_blocksize;
-  m_img->m_file.seek(pos);
+  uint64_t pos = (uint64_t)adds * m_img->m_blocksize;
+  m_img->m_file.seekSet(pos);
   for(uint32_t i = 0; i < len; i++) {
     m_resetJmp = true;
 #if WRITE_SPEED_OPTIMIZE
@@ -1093,8 +1093,8 @@ void verifyDataPhaseSD(uint32_t adds, uint32_t len)
   SCSI_PHASE_CHANGE(SCSI_PHASE_DATAOUT);
   //Bus settle delay 400ns, file.seek() measured at over 1000ns.
 
-  uint32_t pos = adds * m_img->m_blocksize;
-  m_img->m_file.seek(pos);
+  uint64_t pos = (uint64_t)adds * m_img->m_blocksize;
+  m_img->m_file.seekSet(pos);
   for(uint32_t i = 0; i < len; i++) {
 #if WRITE_SPEED_OPTIMIZE
     readDataLoop(m_img->m_blocksize, m_buf);


### PR DESCRIPTION
Changed the file position calculation to 64bit to handle image files larger than 4GB.

I tested this with Sedit. Before this change, sectors are aliasing every 4GB (0x80000 blocks). Reading block 0x800000 is the same as block 0, and writing to block 0x800000 overwrites block 0. After this change, everything works as expected.

In a quick test on an LC III+, I did notice a very small performance regression, maybe 1-2%, which I was not expecting. This calculation is only done once per transfer, and the STM32F103 has hardware support for long multiply (umull), so I wouldn't expect these code changes to have a direct impact on performance. I'm guessing there is some sort of alignment sensitivity in writeDataPhaseSD and readDataPhaseSD. Haven't had a chance to investigate that yet.