### PR TITLE
Add support for the APM32F103C8T6 chip, a clone of the STM32F103

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -29,6 +29,14 @@ board = genericSTM32F103C8
 board_build.mcu = stm32f103c8t6
 board_build.core = maple
 
+[env:APM32F103C8]
+# The APM32F1's default clock is 96MHz and runs unstable at 72MHz(STM32F1's default)
+extends = env:STM32F103C8
+# Explicilty define the multiplier as maple only handles a few cases.
+build_flags = ${env.build_flags} -DBOARD_RCC_PLLMUL=RCC_PLLMUL_12 #96000000L
+# Or go all out at 128Mhz, your call :)
+#board_build.f_cpu = 128000000L
+
 [env:STM32F103C8-XCVR]
 extends = env:STM32F103C8
 build_flags = ${env.build_flags} -DXCVR


### PR DESCRIPTION
Got a few APM32F103C8T6 clones. Unfortunately(and oddly) they were rebadged to STM32 - I'm not sure why because the APM32 seems to perform better! The easy way to tell is if you get a chip (even if it has a STM badge on it) and it shows 256kb - It's likely one of these chips. The other behavior is they are unstable at the stock 72MHz - but run fine at 96-128MHz.

This PR adds a profile to build a bin for this chip, the only change is to set the clock to 96MHz.

Link to data sheet.
http://apexsemi.geehy.com/uploads/tool/APM32F103x4x6x8xB%C2%A0Datasheet%C2%A0V1.2.pdf