### PR TITLE
onInquiryCommand(): return unsupported logical unit if lun is unconfigured

### DIFF
--- a/src/BlueSCSI.cpp
+++ b/src/BlueSCSI.cpp
@@ -1093,6 +1093,11 @@ void verifyDataPhaseSD(uint32_t adds, uint32_t len)
  */
 byte onInquiryCommand(byte len)
 {
+  if (m_img == 0) {
+    SCSI_INFO_BUF[0] = 0x7f;
+  } else {
+    SCSI_INFO_BUF[0] = 0x0;
+  }
   writeDataPhase(len < 36 ? len : 36, SCSI_INFO_BUF);
   return SCSI_STATUS_GOOD;
 }


### PR DESCRIPTION
on sparcstations, bluescsi gets listed 8 times (mentioned briefly in comments in #50). this simple patch makes the device appear only if the lun has actually been configured.