### PR TITLE
Pin SdFat to 2.0.6

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -6,7 +6,7 @@ default_envs = STM32F1
 [env]
 framework = arduino
 lib_deps =
-    greiman/SdFat @ ^2.0.6
+    greiman/SdFat @ 2.0.6
 upload_protocol = stlink
 ; Different gcc versions produce much different binaries in terms of speed.
 platform_packages = platformio/toolchain-gccarmnoneeabi@1.90301.200702
@@ -67,7 +67,7 @@ board_build.mcu = stm32f103c8t6
 board_build.core = maple
 framework = arduino
 lib_deps =
-    greiman/SdFat @ ^2.0.6
+    greiman/SdFat @ 2.0.6
 upload_protocol = dfu
 ; Different gcc versions produce much different binaries in terms of speed.
 platform_packages = platformio/toolchain-gccarmnoneeabi@1.90301.200702


### PR DESCRIPTION
Allow CI to run.
2.2.0 has a lot of changes, need to go through them.