### PR TITLE
Ensure allocLength is defined when needed in onReadBuffer

### DIFF
--- a/src/BlueSCSI.cpp
+++ b/src/BlueSCSI.cpp
@@ -1936,6 +1936,9 @@ byte onReadBuffer(SCSI_DEVICE *dev, const byte *cdb)
 {
   byte mode = cdb[1] & 7; 
   unsigned m_scsi_buf_size = 0;
+  #if DEBUG > 0
+  uint32_t allocLength = ((uint32_t)cdb[6] << 16) | ((uint32_t)cdb[7] << 8) | cdb[8];
+  #endif
   
   LOGN("-ReadBuffer");
   LOGHEXN(mode);
@@ -1955,7 +1958,6 @@ byte onReadBuffer(SCSI_DEVICE *dev, const byte *cdb)
     writeDataPhase(4 + m_scsi_buf_size, m_buf);
 
     #if DEBUG > 0
-    uint32_t allocLength = ((uint32_t)cdb[6] << 16) | ((uint32_t)cdb[7] << 8) | cdb[8];
     for (unsigned i = 0; i < allocLength; i++) {
       LOGHEX(m_scsi_buf[i]);LOG(" ");
     }


### PR DESCRIPTION
While looking in to another issue, I discovered that debug builds were broken due to a variable only being defined in a later conditional. This change moves it back up to a common point where it is a available for all debugging output