### PR TITLE
Fix some compiler warnings

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -11,9 +11,7 @@ upload_protocol = stlink
 ; Different gcc versions produce much different binaries in terms of speed.
 platform_packages = platformio/toolchain-gccarmnoneeabi@1.90301.200702
 build_flags = 
-    -DARDUINO_GENERIC_STM32F103C
     -DARDUINO_LIB_DISCOVERY_PHASE
-    -DARDUINO=10813
     -DARDUINO_ARCH_STM32
     -DDEBUG_LEVEL=DEBUG_NONE
     -O2
@@ -78,9 +76,7 @@ build_flags =
     -D USB_MANUFACTURER="Unknown"
     -D USB_PRODUCT="\"BLUEPILL_F103C8\""
     -D HAL_PCD_MODULE_ENABLED
-    -DARDUINO_GENERIC_STM32F103C
     -DARDUINO_LIB_DISCOVERY_PHASE
-    -DARDUINO=10813
     -DARDUINO_ARCH_STM32
     -DDEBUG_LEVEL=DEBUG_NONE
     -O2

--- a/src/BlueSCSI.h
+++ b/src/BlueSCSI.h
@@ -235,7 +235,7 @@ enum SCSI_DEVICE_TYPE
 // Put DB and DP in output mode
 #define SCSI_DB_OUTPUT() { PBREG->CRL=(PBREG->CRL &0xfffffff0)|DB_MODE_OUT; PBREG->CRH = 0x11111111*DB_MODE_OUT; }
 // Put DB and DP in input mode
-#define SCSI_DB_INPUT()  { PBREG->CRL=(PBREG->CRL &0xfffffff0)|DB_MODE_IN ; PBREG->CRH = (uint32_t)(0x11111111*DB_MODE_IN); }
+#define SCSI_DB_INPUT()  { PBREG->CRL=(PBREG->CRL &0xfffffff0)|DB_MODE_IN ; PBREG->CRH = (uint32_t)0x11111111*DB_MODE_IN; }
 
 // HDDiamge file
 #define HDIMG_ID_POS  2                 // Position to embed ID number


### PR DESCRIPTION
 - Fix syntax of a cast to a uint32
 - Remove defines that are already made by the base platform

Cleans up platform.io compile output quite a bit, making it much easier to spot other errors/warnings, of which there is still one, but I'm not sure if it's legitimate, and if so, how to fix it:
```
src/BlueSCSI.cpp: In function 'void longjmpFromInterrupt(int*, int)':
src/BlueSCSI.cpp:790:1: warning: 'noreturn' function does return
  790 | }
      | ^
```