### PR TITLE
Reformatted Logging

### DIFF
--- a/src/BlueSCSI.cpp
+++ b/src/BlueSCSI.cpp
@@ -653,7 +653,8 @@ void findDriveImages(FsFile root) {
         if(tmp_id > -1 && tmp_id <= MAX_SCSIID) {
           id = tmp_id;
         } else {
-          LOG_FILE.println("\t\tWARNING: Bad SCSI ID in filename, Using default ID 1");
+          LOG_FILE.print("\t\tWARNING: Bad SCSI ID in filename, Using default ID ");
+          LOG_FILE.println(id);
         }
       }
 
@@ -664,7 +665,8 @@ void findDriveImages(FsFile root) {
         if(tmp_lun > -1 && tmp_lun <= NUM_SCSILUN) {
           lun = tmp_lun;
         } else {
-          LOG_FILE.println("\t\tWARNING: Bad SCSI LUN in filename, Using default LUN ID 0");
+          LOG_FILE.print("\t\tWARNING: Bad SCSI LUN in filename, Using default LUN ID ");
+          LOG_FILE.println(lun);
         }
       }
 

--- a/src/BlueSCSI.cpp
+++ b/src/BlueSCSI.cpp
@@ -339,7 +339,6 @@ bool hddimageOpen(SCSI_DEVICE *dev, FsFile *file,int id,int lun,int blocksize)
   return true; // File opened
 
 failed:
-
   dev->m_file.close();
   dev->m_fileSize = dev->m_blocksize = 0; // no file
   //delete dev->m_file;
@@ -463,12 +462,12 @@ void setup()
   TRANSCEIVER_IO_SET(vTR_INITIATOR,TR_INPUT);
 #endif
 
-  //GPIO(SCSI BUS)Initialization
-  //Port setting register (lower)
-//  GPIOB->regs->CRL |= 0x000000008; // SET INPUT W/ PUPD on PAB-PB0
-  //Port setting register (upper)
-  //GPIOB->regs->CRH = 0x88888888; // SET INPUT W/ PUPD on PB15-PB8
-//  GPIOB->regs->ODR = 0x0000FF00; // SET PULL-UPs on PB15-PB8
+  // GPIO(SCSI BUS)Initialization
+  // Port setting register (lower)
+  // GPIOB->regs->CRL |= 0x000000008; // SET INPUT W/ PUPD on PAB-PB0
+  // Port setting register (upper)
+  // GPIOB->regs->CRH = 0x88888888; // SET INPUT W/ PUPD on PB15-PB8
+  // GPIOB->regs->ODR = 0x0000FF00; // SET PULL-UPs on PB15-PB8
   // DB and DP are input modes
   SCSI_DB_INPUT()
 
@@ -635,7 +634,7 @@ void findDriveImages(FsFile root) {
       int lun = 0;
       int blk = 512;
 
-      // Positionally read in and coerase the chars to integers.
+      // Positionally read in and coerce the chars to integers.
       // We only require the minimum and read in the next if provided.
       int file_name_length = strlen(name);
       if(file_name_length > 2) { // HD[N]

--- a/src/BlueSCSI.h
+++ b/src/BlueSCSI.h
@@ -182,7 +182,7 @@ enum SCSI_DEVICE_TYPE
 |  1 | 1 | 1  |  MESSAGE IN   |       Initiator from target   /  |  phase     |
 |-----------------------------------------------------------------------------|
 | Key:  0 = False,  1 = True,  * = Reserved for future standardization        |
-+=============================================================================+ 
++=============================================================================+
 */
 // SCSI phase change as single write to port B
 #define SCSIPHASEMASK(MSGACTIVE, CDACTIVE, IOACTIVE) ((BITMASK(vMSG)<<((MSGACTIVE)?16:0)) | (BITMASK(vCD)<<((CDACTIVE)?16:0)) | (BITMASK(vIO)<<((IOACTIVE)?16:0)))
@@ -340,15 +340,15 @@ typedef struct _SCSI_INQUIRY_DATA
 // HDD image
 typedef __attribute__((aligned(4))) struct _SCSI_DEVICE
 {
-	FsFile        m_file;                  // File object
-	uint64_t      m_fileSize;               // File size
-	uint16_t      m_blocksize;              // SCSI BLOCK size
+  FsFile        m_file;                   // File object
+  uint64_t      m_fileSize;               // File size
+  uint16_t      m_blocksize;              // SCSI BLOCK size
   uint16_t      m_rawblocksize;           // OPTICAL raw sector size
   uint8_t       m_type;                   // SCSI device type
   uint32_t      m_blockcount;             // blockcount
-  SCSI_INQUIRY_DATA inquiry_block;       // SCSI information
+  SCSI_INQUIRY_DATA inquiry_block;        // SCSI information
   uint8_t       m_senseKey;               // Sense key
-  uint16_t      m_additional_sense_code;  // ASC/ASCQ 
+  uint16_t      m_additional_sense_code;  // ASC/ASCQ
   uint8_t       m_sector_offset;          // optical sector offset for missing sync header
   uint8_t       flags;                    // various device flags
 } SCSI_DEVICE;


### PR DESCRIPTION
This PR is mainly focused on cleaner/more informative logging, keeping information grouped with the section/file it belongs with.

The PR also endeavours to make better use of constants and macros, and use a consistent convention around char array lengths. There's also some light whitespace cleanup and fixing of a few typos.

The largest functional change in the PR is the change from `finalizeFileLog` to `finalizeDevices`. This function now contains the call to `readSCSIDeviceConfig` in the case that two files are defined with the same ID, so that it is only called once, and the function now also outputs the filename that is being served for the ID to make absolutely clear on what IDs the drive image should be appearing.

This PR doesn't make any changes to anything that runs in the loop, so hopefully there will not be any performance impacts, although some of the discussion in #118 leads me to worry that even changes outside the loop could have performance impacts.

(I also see that PR #261 just came in, I'm happy to rebase if that PR is merged)

Here's an example of the new log output, including the case where two files with the same ID are seen, to show that the "devices table" indicates that the last ID detected is the one used:
```
BlueSCSI https://github.com/erichelgeson/BlueSCSI
VER: 1.1-20231117-SNAPSHOT-USB DEBUG: 0
SD Card Info:
 SPI Speed: 50MHz
 Format: FAT32/16/12 - exFAT may improve performance
 Max Filename Length: 64
 MID: 1B OID: SM
 Name: GC1S5 Date: 9/2021
 Serial: 3782502390
Looking for images in: /
 HD10_512 200MB.hda
 Parsed: HDD ID 1 LUN 0 Blocksize 512k
 WARNING: Fragmented, see https://github.com/erichelgeson/BlueSCSI/wiki/Image-File-Fragmentation
 File size: 209780736 bytes, 204864KiB, 200MiB

 HD10_512 200MB Duplicate.hda
 Parsed: HDD ID 1 LUN 0 Blocksize 512k
 WARNING: Fragmented, see https://github.com/erichelgeson/BlueSCSI/wiki/Image-File-Fragmentation
 File size: 209780736 bytes, 204864KiB, 200MiB

SCSI Devices
ID	LUN	Name
0	0	-
1	0	HD10_512 200MB Duplicate.hda
		INI Overrides: Forced HDD / Vendor: SEAGATE / Product: ST225N / Revision: 9
2	0	-
3	0	-
4	0	-
5	0	-
6	0	-
Finished configuration - Starting BlueSCSI
```